### PR TITLE
NOUPSTREAM: arm64/ras: Treat single-bit ECC error in the MMU TC RAM a…

### DIFF
--- a/arch/arm64/include/asm/ras.h
+++ b/arch/arm64/include/asm/ras.h
@@ -25,6 +25,9 @@
 #define ERR_FR_8B_CEC		BIT(1)
 #define ERR_FR_16B_CEC		BIT(2)
 
+#define ARM_N1_MISC0_UNIT_MASK	0xf
+#define ARM_N1_UNIT_L2_TLB	0x2
+
 struct ras_ext_regs {
 	u64 err_fr;
 	u64 err_ctlr;


### PR DESCRIPTION
…s fatal

A transient single-bit ECC error in the MMU TC RAM might lead to stale
translation in the L2 TLB. Treat this condition as an uncontainable
uncorrected error.

Signed-off-by: Tyler Baicar <baicar@os.amperecomputing.com>
Signed-off-by: Bobo <lmw.bobo@gmail.com>