### PR TITLE
Fix UnicodeDecodeError and clean-up code

### DIFF
--- a/tests/lkft/kselftest/parse_result.py
+++ b/tests/lkft/kselftest/parse_result.py
@@ -40,7 +40,9 @@ with open(sys.argv[1], "r") as fp_in:
             fp_out.write("{},{},{}\n".format(*match_ok.groups(), "OK"))
             tests_ok += 1
 
-fp_out.write("kselftests: total {} pass {} skip {} fail {}".format(
-        tests_sum, tests_ok, tests_skip, tests_fail))
+fp_out.write(
+    "kselftests: total {} pass {} skip {} fail {}".format(
+        tests_sum, tests_ok, tests_skip, tests_fail
+    )
+)
 fp_out.close()
-

--- a/tests/lkft/kselftest/parse_result.py
+++ b/tests/lkft/kselftest/parse_result.py
@@ -1,21 +1,20 @@
 #!/bin/env python3
 
-import sys
+import argparse
 import re
+import sys
 
 
 def main() -> int:
-    if len(sys.argv) != 3:
-        print("Usage:\n\t{} kselftest.txt output.csv".format(sys.argv[0]))
-        sys.exit(1)
+    args = parse_args()
 
-    fp_out = open(sys.argv[2], "w")
+    fp_out = open(args.output_csv_file, "w")
 
     tests_sum = 0
     tests_ok = 0
     tests_skip = 0
     tests_fail = 0
-    with open(sys.argv[1], "r") as fp_in:
+    with open(args.kselftest_log, "r") as fp_in:
         for line in fp_in:
             if re.match("^# selftests: (.+: .+)$", line):
                 tests_sum += 1
@@ -49,6 +48,24 @@ def main() -> int:
     )
     fp_out.close()
     return 0
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+
+    parser.add_argument(
+        "kselftest_log",
+        help="kselftest.txt log file",
+        metavar="kselftest.txt",
+    )
+    parser.add_argument(
+        "output_csv_file",
+        help="Name of the CSV file to save the output to",
+        metavar="output.csv",
+    )
+
+    args = parser.parse_args()
+    return args
 
 
 if "__main__" == __name__:

--- a/tests/lkft/kselftest/parse_result.py
+++ b/tests/lkft/kselftest/parse_result.py
@@ -3,46 +3,53 @@
 import sys
 import re
 
-if len(sys.argv) != 3:
-    print("Usage:\n\t{} kselftest.txt output.csv".format(sys.argv[0]))
-    sys.exit(1)
 
-fp_out = open(sys.argv[2], "w")
+def main() -> int:
+    if len(sys.argv) != 3:
+        print("Usage:\n\t{} kselftest.txt output.csv".format(sys.argv[0]))
+        sys.exit(1)
 
-tests_sum = 0
-tests_ok = 0
-tests_skip = 0
-tests_fail = 0
-with open(sys.argv[1], "r") as fp_in:
-    for line in fp_in:
-        if re.match("^# selftests: (.+: .+)$", line):
-            tests_sum += 1
-            continue
+    fp_out = open(sys.argv[2], "w")
 
-        match_notok = re.match("^not ok \d+ selftests: (.+): (.+) # (.+)$", line)
-        if match_notok:
-            fp_out.write("{},{},{}\n".format(*match_notok.groups()))
-            if "SKIP" in match_notok.group(3):
+    tests_sum = 0
+    tests_ok = 0
+    tests_skip = 0
+    tests_fail = 0
+    with open(sys.argv[1], "r") as fp_in:
+        for line in fp_in:
+            if re.match("^# selftests: (.+: .+)$", line):
+                tests_sum += 1
+                continue
+
+            match_notok = re.match("^not ok \d+ selftests: (.+): (.+) # (.+)$", line)
+            if match_notok:
+                fp_out.write("{},{},{}\n".format(*match_notok.groups()))
+                if "SKIP" in match_notok.group(3):
+                    tests_skip += 1
+                else:
+                    tests_fail += 1
+                continue
+
+            # match 5.10 skip output
+            match_skip = re.match("^.*ok \d+ selftests: (.+): (.+) # SKIP$", line)
+            if match_skip:
+                fp_out.write("{},{},{}\n".format(*match_skip.groups(), "SKIP"))
                 tests_skip += 1
-            else:
-                tests_fail += 1
-            continue
+                continue
 
-        # match 5.10 skip output
-        match_skip = re.match("^.*ok \d+ selftests: (.+): (.+) # SKIP$", line)
-        if match_skip:
-            fp_out.write("{},{},{}\n".format(*match_skip.groups(), "SKIP"))
-            tests_skip += 1
-            continue
+            match_ok = re.match("^.*ok \d+ selftests: (.+): (.+)$", line)
+            if match_ok:
+                fp_out.write("{},{},{}\n".format(*match_ok.groups(), "OK"))
+                tests_ok += 1
 
-        match_ok = re.match("^.*ok \d+ selftests: (.+): (.+)$", line)
-        if match_ok:
-            fp_out.write("{},{},{}\n".format(*match_ok.groups(), "OK"))
-            tests_ok += 1
-
-fp_out.write(
-    "kselftests: total {} pass {} skip {} fail {}".format(
-        tests_sum, tests_ok, tests_skip, tests_fail
+    fp_out.write(
+        "kselftests: total {} pass {} skip {} fail {}".format(
+            tests_sum, tests_ok, tests_skip, tests_fail
+        )
     )
-)
-fp_out.close()
+    fp_out.close()
+    return 0
+
+
+if "__main__" == __name__:
+    sys.exit(main())

--- a/tests/lkft/kselftest/parse_result.py
+++ b/tests/lkft/kselftest/parse_result.py
@@ -13,7 +13,7 @@ def main() -> int:
         tests_ok = 0
         tests_skip = 0
         tests_fail = 0
-        with open(args.kselftest_log, "r") as fp_in:
+        with open(args.kselftest_log, "r", encoding="utf-8", errors="replace") as fp_in:
             for line in fp_in:
                 if re.match("^# selftests: (.+: .+)$", line):
                     tests_sum += 1


### PR DESCRIPTION
Fix a UnicodeDecodeError we are seeing in our testing.

```
    Traceback (most recent call last):
      File "/home/devel/ampere-lts-kernel/tests/lkft/kselftest/./parse_result.py", line 73, in <module>
        sys.exit(main())
      File "/home/devel/ampere-lts-kernel/tests/lkft/kselftest/./parse_result.py", line 18, in main
        for line in fp_in:
      File "/usr/lib64/python3.10/codecs.py", line 322, in decode
        (result, consumed) = self._buffer_decode(data, self.errors, final)
    UnicodeDecodeError: 'utf-8' codec can't decode byte 0xe5 in position 8093: invalid continuation byte
```